### PR TITLE
0.5.0-alpha.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.5.0-alpha.15 — May 1, 2026
+- Pick up [Markdown Language Service](https://github.com/microsoft/vscode-markdown-languageservice) 0.5.0-alpha.13. See [CHANGELOG](https://github.com/microsoft/vscode-markdown-languageservice/blob/main/CHANGELOG.md#050-alpha13--april-30-2026) for details.
+- Switched to ship server as esm
+
 # 0.5.0-alpha.14 — April 29, 2026
 - Switch back to shipping bundled server file
 

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -14,11 +14,34 @@ const watch = process.argv.includes('--watch');
 
 // Resolve to the top-level copy to avoid duplicate nested copies
 const l10nPath = path.dirname(require.resolve('@vscode/l10n/package.json'));
+const vscodeUriEsmPath = path.join(path.dirname(require.resolve('vscode-uri')), '..', 'esm', 'index.mjs');
+
+/** @type {esbuild.Plugin} */
+const vscodeUriDefaultExportPlugin = {
+    name: 'vscode-uri-default-export',
+    setup(build) {
+        build.onResolve({ filter: /^vscode-uri$/ }, () => ({
+            path: 'vscode-uri-default-export',
+            namespace: 'vscode-uri-default-export',
+        }));
+        build.onLoad({ filter: /.*/, namespace: 'vscode-uri-default-export' }, () => ({
+            contents: [
+                `import { URI, Utils } from ${JSON.stringify(vscodeUriEsmPath)};`,
+                'const uri = { URI, Utils };',
+                'export { URI, Utils };',
+                'export default uri;',
+            ].join('\n'),
+            loader: 'js',
+            resolveDir: '/',
+        }));
+    },
+};
 
 /** @type {esbuild.BuildOptions} */
 const baseConfig = {
-    target: 'es2022',
+    target: 'es2024',
     sourcemap: true,
+    plugins: [vscodeUriDefaultExportPlugin],
 };
 
 /** @type {esbuild.BuildOptions} */
@@ -28,8 +51,18 @@ const nodeConfig = {
     outfile: 'dist/node/workerMain.js',
     outbase: 'src',
     bundle: true,
-    format: 'cjs',
+    format: 'esm',
     platform: 'node',
+    banner: {
+        js: [
+            "import { createRequire as __createRequire } from 'node:module';",
+            "import { fileURLToPath as __fileURLToPath } from 'node:url';",
+            "import { dirname as __dirnamePath } from 'node:path';",
+            'const require = __createRequire(import.meta.url);',
+            'const __filename = __fileURLToPath(import.meta.url);',
+            'const __dirname = __dirnamePath(__filename);',
+        ].join('\n'),
+    },
 };
 
 /** @type {esbuild.BuildOptions} */
@@ -38,10 +71,8 @@ const browserConfig = {
     entryPoints: ['src/browser/workerMain.ts'],
     outfile: 'dist/browser/workerMain.js',
     bundle: true,
-    format: 'iife',
-    globalName: 'serverExportVar',
+    format: 'esm',
     platform: 'browser',
-    external: ['vscode'],
     define: {
         'process.platform': JSON.stringify('web'),
         'process.env': JSON.stringify({}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "vscode-markdown-languageserver",
-  "version": "0.5.0-alpha.14",
+  "version": "0.5.0-alpha.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-languageserver",
-      "version": "0.5.0-alpha.14",
+      "version": "0.5.0-alpha.15",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.11",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-languageserver-types": "^3.17.5",
-        "vscode-markdown-languageservice": "^0.5.0-alpha.12",
+        "vscode-markdown-languageservice": "^0.5.0-alpha.13",
         "vscode-uri": "^3.0.7"
       },
       "devDependencies": {
@@ -855,9 +855,9 @@
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/vscode-markdown-languageservice": {
-      "version": "0.5.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.5.0-alpha.12.tgz",
-      "integrity": "sha512-B/83R1iVz2iJ7P1NdqL43Larj554q7Bd5FxK7HLoz8qCRedbOL5Qtf9vXi687ZtOfUHJYYaohp1vX3XpXRRHMQ==",
+      "version": "0.5.0-alpha.13",
+      "resolved": "https://registry.npmjs.org/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.5.0-alpha.13.tgz",
+      "integrity": "sha512-uxEdsSXdh5Bi/q1kymcqv0JziAN4gi02YPOXhqlEahsgiVGd/5cWGSJIL6hIaRtql3wBgRDNqI7CrOsODh0Yqg==",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
@@ -868,7 +868,7 @@
         "vscode-uri": "^3.0.7"
       },
       "engines": {
-        "node": "*"
+        "node": ">=18"
       }
     },
     "node_modules/vscode-markdown-languageservice/node_modules/@vscode/l10n": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageserver",
   "description": "The language server that powers VS Code's Markdown support",
-  "version": "g5",
+  "version": "0.5.0-alpha.15",
   "type": "module",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "vscode-markdown-languageserver",
   "description": "The language server that powers VS Code's Markdown support",
-  "version": "0.5.0-alpha.14",
+  "version": "g5",
+  "type": "module",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {
@@ -17,7 +18,7 @@
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-languageserver-types": "^3.17.5",
-    "vscode-markdown-languageservice": "^0.5.0-alpha.12",
+    "vscode-markdown-languageservice": "^0.5.0-alpha.13",
     "vscode-uri": "^3.0.7"
   },
   "overrides": {


### PR DESCRIPTION
Also switches us to esm. Has to workaround a slight annoyance with `vscode-uri` which I'll look into fixing upstream