### PR TITLE
Remove `any` hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 0.5.0-alpha.16 — June 2, 2026
+- Fix so clients can use correct lsp types.
+
 # 0.5.0-alpha.15 — May 1, 2026
 - Pick up [Markdown Language Service](https://github.com/microsoft/vscode-markdown-languageservice) 0.5.0-alpha.13. See [CHANGELOG](https://github.com/microsoft/vscode-markdown-languageservice/blob/main/CHANGELOG.md#050-alpha13--april-30-2026) for details.
 - Switched to ship server as esm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-languageserver",
-  "version": "0.5.0-alpha.15",
+  "version": "0.5.0-alpha.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-languageserver",
-      "version": "0.5.0-alpha.15",
+      "version": "0.5.0-alpha.16",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.11",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageserver",
   "description": "The language server that powers VS Code's Markdown support",
-  "version": "0.5.0-alpha.15",
+  "version": "0.5.0-alpha.16",
   "type": "module",
   "author": "Microsoft Corporation",
   "license": "MIT",


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/298733

I believe the root cause of this was clients sending a `vscode.Range` instead of the `lsp.Range`